### PR TITLE
Upgrade golangci-lint-action version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.27
+          version: v1.29
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func VerifyToken(next http.Handler, tokenVerifier *oidc.IDTokenVerifier, cfg *Co
 		accessJWT := headers.Get(CFJWTHeader)
 		if accessJWT == "" {
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte("No token on the request"))
+			w.Write([]byte("No token on the request")) //nolint: errcheck
 			return
 		}
 
@@ -69,7 +69,7 @@ func VerifyToken(next http.Handler, tokenVerifier *oidc.IDTokenVerifier, cfg *Co
 		token, err := tokenVerifier.Verify(ctx, accessJWT)
 		if err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(fmt.Sprintf("Invalid token: %s", err.Error())))
+			w.Write([]byte(fmt.Sprintf("Invalid token: %s", err.Error()))) //nolint: errcheck
 			return
 		}
 
@@ -77,7 +77,7 @@ func VerifyToken(next http.Handler, tokenVerifier *oidc.IDTokenVerifier, cfg *Co
 		var claims CloudflareClaim
 		if err := token.Claims(&claims); err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(fmt.Sprintf("Invalid claims in token: %s", err.Error())))
+			w.Write([]byte(fmt.Sprintf("Invalid claims in token: %s", err.Error()))) //nolint: errcheck
 		}
 
 		// set the authentication forward header before proxying the request


### PR DESCRIPTION
This PR also adds a couple of `//nolint` directives to skip some validations.